### PR TITLE
Fix opt for real

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = { version = "3.1", optional = true }
 
 [dev-dependencies]
 structopt = "0.3"
+difference = "2.0"
 
 [[example]]
 name = "as"

--- a/spirv-tools-sys/src/assembler.rs
+++ b/spirv-tools-sys/src/assembler.rs
@@ -6,6 +6,31 @@ pub enum BinaryOptions {
     PreserveNumberIds = 1 << 1,
 }
 
+#[repr(C)]
+pub struct Text {
+    pub data: *const std::os::raw::c_char,
+    pub length: usize,
+}
+
+pub enum DisassembleOptions {
+    None = 0x1,
+    /// Print to stdout
+    Print = 0x2,
+    /// Add color codes to output
+    Color = 0x4,
+    /// Indent assembly
+    Indent = 0x8,
+    ShowByteOffset = 0x10,
+    /// Do not output the module header as leading comments in the assembly.
+    NoHeader = 0x20,
+    /// Use friendly names where possible.  The heuristic may expand over
+    /// time, but will use common names for scalar types, and debug names from
+    /// OpName instructions.
+    FriendlyNames = 0x40,
+    /// Add some comments to the generated assembly
+    Comment = 0x80,
+}
+
 extern "C" {
     /// Encodes the given SPIR-V assembly text to its binary representation. The
     /// length parameter specifies the number of bytes for text. Encoded binary will
@@ -26,4 +51,25 @@ extern "C" {
         binary: *mut *mut shared::Binary,
         diagnostic: *mut *mut crate::diagnostics::Diagnostic,
     ) -> shared::SpirvResult;
+
+    /// Decodes the given SPIR-V binary representation to its assembly text. The
+    /// word_count parameter specifies the number of words for binary. The options
+    /// parameter is a bit field of spv_binary_to_text_options_t. Decoded text will
+    /// be stored into *text. Any error will be written into *diagnostic if
+    /// diagnostic is non-null, otherwise the context's message consumer will be
+    /// used.
+    #[link_name = "spvBinaryToText"]
+    pub fn disassemble(
+        tool: *const shared::ToolContext,
+        binary: *const u32,
+        size: usize,
+        options: u32,
+        out_text: *mut *mut Text,
+        diagnostic: *mut *mut crate::diagnostics::Diagnostic,
+    ) -> shared::SpirvResult;
+
+    /// Frees an allocated text stream. This is a no-op if the text parameter
+    /// is a null pointer.
+    #[link_name = "spvTextDestroy"]
+    pub fn text_destroy(text: *mut Text);
 }

--- a/spirv-tools-sys/src/c/opt.cpp
+++ b/spirv-tools-sys/src/c/opt.cpp
@@ -136,18 +136,21 @@ extern "C" {
             return SPV_ERROR_INTERNAL;
         }
 
-        uint32_t* data = new uint32_t[output_buff.size()];
+        auto word_count = output_buff.size();
+        auto data_byte_count = word_count * 4;
+
+        uint32_t* data = new uint32_t[word_count];
         if (data == nullptr) {
             return SPV_ERROR_OUT_OF_MEMORY;
         }
 
-        spv_binary binary = new spv_binary_t { data, output_buff.size() };
+        spv_binary binary = new spv_binary_t { data, word_count };
         if (binary == nullptr) {
             delete[] data;
             return SPV_ERROR_OUT_OF_MEMORY;
         }
 
-        memcpy(data, output_buff.data(), output_buff.size());
+        memcpy(data, output_buff.data(), data_byte_count);
         *out_binary = binary;
 
         return SPV_SUCCESS;

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -26,6 +26,75 @@ impl Into<u32> for AssemblerOptions {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct DisassembleOptions {
+    /// Print to stdout.
+    pub print: bool,
+    /// Add color codes to output
+    pub color: bool,
+    /// Indent assembly
+    pub indent: bool,
+    pub show_byte_offset: bool,
+    /// Do not output the module header as leading comments in the assembly.
+    pub no_header: bool,
+    /// Use friendly names where possible.  The heuristic may expand over
+    /// time, but will use common names for scalar types, and debug names from
+    /// OpName instructions.
+    pub use_friendly_names: bool,
+    /// Add some comments to the generated assembly
+    pub comment: bool,
+}
+
+impl Default for DisassembleOptions {
+    fn default() -> Self {
+        Self {
+            print: false,
+            color: false,
+            indent: true,
+            show_byte_offset: false,
+            no_header: false,
+            use_friendly_names: true,
+            comment: true,
+        }
+    }
+}
+
+impl Into<u32> for DisassembleOptions {
+    fn into(self) -> u32 {
+        let mut res = 0;
+
+        if self.print {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::Print as u32;
+        }
+
+        if self.color {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::Color as u32;
+        }
+
+        if self.indent {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::Indent as u32;
+        }
+
+        if self.show_byte_offset {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::ShowByteOffset as u32;
+        }
+
+        if self.no_header {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::NoHeader as u32;
+        }
+
+        if self.use_friendly_names {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::FriendlyNames as u32;
+        }
+
+        if self.comment {
+            res |= spirv_tools_sys::assembler::DisassembleOptions::Comment as u32;
+        }
+
+        res
+    }
+}
+
 pub trait Assembler: Default {
     fn with_env(target_env: crate::TargetEnv) -> Self;
     fn assemble(
@@ -33,6 +102,11 @@ pub trait Assembler: Default {
         text: &str,
         options: AssemblerOptions,
     ) -> Result<crate::binary::Binary, crate::error::Error>;
+    fn disassemble(
+        &self,
+        binary: impl AsRef<[u32]>,
+        options: DisassembleOptions,
+    ) -> Result<String, crate::error::Error>;
 }
 
 pub fn create(te: Option<crate::TargetEnv>) -> impl Assembler {

--- a/src/assembler/tool.rs
+++ b/src/assembler/tool.rs
@@ -15,7 +15,7 @@ impl Assembler for ToolAssembler {
         options: super::AssemblerOptions,
     ) -> Result<crate::binary::Binary, crate::error::Error> {
         let mut cmd = std::process::Command::new("spirv-as");
-        cmd.arg("--target-env").arg(self.target_env.to_string());
+        cmd.arg(format!("--target-env={}", self.target_env));
 
         if options.preserve_numeric_ids {
             cmd.arg("--preserve-numeric-ids");
@@ -26,6 +26,47 @@ impl Assembler for ToolAssembler {
 
         use std::convert::TryFrom;
         crate::binary::Binary::try_from(cmd_output.binary)
+    }
+
+    fn disassemble(
+        &self,
+        binary: impl AsRef<[u32]>,
+        options: super::DisassembleOptions,
+    ) -> Result<String, crate::error::Error> {
+        let mut cmd = std::process::Command::new("spirv-dis");
+
+        if options.color {
+            cmd.arg("--color");
+        }
+
+        if !options.indent {
+            cmd.arg("--no-indent");
+        }
+
+        if options.show_byte_offset {
+            cmd.arg("--offsets");
+        }
+
+        if options.no_header {
+            cmd.arg("--no-header");
+        }
+
+        if !options.use_friendly_names {
+            cmd.arg("--raw-id");
+        }
+
+        if options.comment {
+            cmd.arg("--comment");
+        }
+
+        let bytes = crate::binary::from_binary(binary.as_ref());
+
+        let cmd_output = crate::cmd::exec(cmd, Some(bytes), crate::cmd::Output::Retrieve)?;
+
+        String::from_utf8(cmd_output.binary).map_err(|_| crate::error::Error {
+            inner: spirv_tools_sys::shared::SpirvResult::InvalidText,
+            diagnostic: Some("spirv disassemble returned non-utf8 text".to_owned().into()),
+        })
     }
 }
 

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -50,6 +50,11 @@ impl Binary {
     pub fn as_bytes(&self) -> &[u8] {
         self.as_ref()
     }
+
+    /// Gets the words for the binary
+    pub fn as_words(&self) -> &[u32] {
+        self.as_ref()
+    }
 }
 
 impl std::convert::TryFrom<Vec<u8>> for Binary {
@@ -89,6 +94,21 @@ impl AsRef<[u8]> for Binary {
             Self::OwnedU32(v) => from_binary(&v),
             Self::OwnedU8(v) => &v,
         }
+    }
+}
+
+use std::fmt;
+
+impl fmt::Debug for Binary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut ds = match self {
+            #[cfg(feature = "use-compiled-tools")]
+            Self::External(_) => f.debug_struct("External"),
+            Self::OwnedU32(_) => f.debug_struct("OwnedU32"),
+            Self::OwnedU8(_) => f.debug_struct("OwnedU8"),
+        };
+
+        ds.field("word_count", &self.as_words().len()).finish()
     }
 }
 

--- a/src/opt/compiled.rs
+++ b/src/opt/compiled.rs
@@ -92,7 +92,7 @@ impl Optimizer for CompiledOptimizer {
 
             let options = options.map(Options::from);
 
-            let options = match options {
+            let options = match &options {
                 Some(opts) => opts.inner,
                 None => std::ptr::null(),
             };

--- a/src/opt/tool.rs
+++ b/src/opt/tool.rs
@@ -28,7 +28,7 @@ impl Optimizer for ToolOptimizer {
         options: Option<super::Options>,
     ) -> Result<crate::binary::Binary, crate::Error> {
         let mut cmd = std::process::Command::new("spirv-opt");
-        cmd.arg("--target-env").arg(self.target_env.to_string());
+        cmd.arg(format!("--target-env={}", self.target_env));
 
         cmd.args(
             self.passes

--- a/src/val.rs
+++ b/src/val.rs
@@ -3,6 +3,8 @@ pub mod compiled;
 #[cfg(feature = "use-installed-tools")]
 pub mod tool;
 
+pub use spirv_tools_sys::val::ValidatorLimits;
+
 #[derive(Default, Clone)]
 pub struct ValidatorOptions {
     /// Record whether or not the validator should relax the rules on types for
@@ -67,14 +69,14 @@ pub struct ValidatorOptions {
     /// uniform/storage block layout.
     pub skip_block_layout: bool,
     /// Applies a maximum to one or more Universal limits
-    pub max_limits: Vec<(spirv_tools_sys::val::ValidatorLimits, u32)>,
+    pub max_limits: Vec<(ValidatorLimits, u32)>,
 }
 
 pub trait Validator: Default {
     fn with_env(target_env: crate::TargetEnv) -> Self;
     fn validate(
         &self,
-        binary: &[u32],
+        binary: impl AsRef<[u32]>,
         options: Option<ValidatorOptions>,
     ) -> Result<(), crate::error::Error>;
 }

--- a/src/val/compiled.rs
+++ b/src/val/compiled.rs
@@ -69,13 +69,15 @@ impl Validator for CompiledValidator {
 
     fn validate(
         &self,
-        binary: &[u32],
+        binary: impl AsRef<[u32]>,
         options: Option<super::ValidatorOptions>,
     ) -> Result<(), crate::error::Error> {
         unsafe {
             let mut diagnostic = std::ptr::null_mut();
 
             let options = options.map(Options::from);
+
+            let binary = binary.as_ref();
 
             let input = shared::Binary {
                 code: binary.as_ptr(),

--- a/src/val/tool.rs
+++ b/src/val/tool.rs
@@ -14,7 +14,7 @@ impl Validator for ToolValidator {
 
     fn validate(
         &self,
-        binary: &[u32],
+        binary: impl AsRef<[u32]>,
         options: Option<super::ValidatorOptions>,
     ) -> Result<(), crate::error::Error> {
         let mut cmd = Command::new("spirv-val");
@@ -25,7 +25,7 @@ impl Validator for ToolValidator {
             add_options(&mut cmd, opts);
         }
 
-        let input = crate::binary::from_binary(binary);
+        let input = crate::binary::from_binary(binary.as_ref());
 
         crate::cmd::exec(cmd, Some(input), crate::cmd::Output::Ignore)?;
         Ok(())

--- a/src/val/tool.rs
+++ b/src/val/tool.rs
@@ -19,9 +19,13 @@ impl Validator for ToolValidator {
     ) -> Result<(), crate::error::Error> {
         let mut cmd = Command::new("spirv-val");
 
-        cmd.arg("--target-env").arg(self.target_env.to_string());
+        cmd.arg(format!("--target-env={}", self.target_env));
 
         if let Some(opts) = options {
+            // We reuse add options when we run the validator before optimizing,
+            // however the optimizer does not recognize limits, so we split them
+            // out into a separate function
+            add_limits(&mut cmd, &opts.max_limits);
             add_options(&mut cmd, opts);
         }
 
@@ -60,8 +64,6 @@ pub(crate) fn add_options(cmd: &mut Command, opts: super::ValidatorOptions) {
     if opts.before_legalization {
         cmd.arg("--before-hlsl-legalization");
     }
-
-    add_limits(cmd, &opts.max_limits);
 }
 
 fn add_limits(cmd: &mut Command, limits: &[(spirv_tools_sys::val::ValidatorLimits, u32)]) {
@@ -69,7 +71,7 @@ fn add_limits(cmd: &mut Command, limits: &[(spirv_tools_sys::val::ValidatorLimit
 
     for (limit, val) in limits {
         cmd.arg(format!(
-            "--max-{}",
+            "--max-{}={}",
             match limit {
                 ValidatorLimits::StructMembers => "struct-members",
                 ValidatorLimits::StructDepth => "struct-depth",
@@ -80,8 +82,8 @@ fn add_limits(cmd: &mut Command, limits: &[(spirv_tools_sys::val::ValidatorLimit
                 ValidatorLimits::ControlFlowNestingDepth => "control-flow-nesting-depth",
                 ValidatorLimits::AccessChainIndexes => "access-chain-indexes",
                 ValidatorLimits::IdBound => "id-bound",
-            }
-        ))
-        .arg(val.to_string());
+            },
+            val
+        ));
     }
 }


### PR DESCRIPTION
This _actually_ fixes the compiled optimizer to be correct (relative to spirv-opt), the problem was two fold.

1. If you set options for the optimizer, they would be freed before running the optimzer, causing the options to be garbage and thus (probably) fail during validation.
2. `memcpy` operates on byte count, but we were using the word count for the size, so the output after optimization was truncated to 1/4 of what it should have been.

This also improves the test to both validate the tool and compiled binaries after optimization, and also dissassembles them and does a text diff to make sure that the tool and compiled paths both give the same exact output for the same input (assembly + options).

Resolves: #10 