### PR TITLE
fix: should not report and null error if disassembled text is printed…

### DIFF
--- a/src/assembler/compiled.rs
+++ b/src/assembler/compiled.rs
@@ -81,7 +81,7 @@ impl Assembler for CompiledAssembler {
 
             match res {
                 shared::SpirvResult::Success => {
-                    if text.is_null() {
+                    if text.is_null() && !options.print {
                         return Err(crate::error::Error {
                             inner: shared::SpirvResult::InternalError,
                             diagnostic: Some(


### PR DESCRIPTION
… other than returned.

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I went into an errot if `print` flag in `DisassembleOptions` is true while it is ok for false.

### Related Issues

None