### PR TITLE
fix: should early return when disassembled text is null

### DIFF
--- a/src/assembler/compiled.rs
+++ b/src/assembler/compiled.rs
@@ -81,8 +81,9 @@ impl Assembler for CompiledAssembler {
 
             match res {
                 shared::SpirvResult::Success => {
-                    if text.is_null() && !options.print {
-                        return Err(crate::error::Error {
+                    if text.is_null() {
+                        if !options.print {
+                            return Err(crate::error::Error {
                             inner: shared::SpirvResult::InternalError,
                             diagnostic: Some(
                                 "spirv disassemble indicated success but did not return valid text"
@@ -90,6 +91,9 @@ impl Assembler for CompiledAssembler {
                                     .into(),
                             ),
                         });
+                        } else {
+                            return Ok(String::default());
+                        }
                     }
 
                     // Sanity check the text first


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

in ``CompiledAssembler::disassemble``, if text is null and print option is on, return a empty string, otherwise it will access a null text afterward

### Related Issues

None
