### PR TITLE
Fix issue 22

### DIFF
--- a/spirv-tools-sys/src/opt.rs
+++ b/spirv-tools-sys/src/opt.rs
@@ -15,12 +15,6 @@ pub enum Passes {
     // Creates a null pass.
     // A null pass does nothing to the SPIR-V module to be optimized.
     Null,
-    // Creates a strip-atomic-counter-memory pass.
-    // A strip-atomic-counter-memory pass removes all usages of the
-    // AtomicCounterMemory bit in Memory Semantics bitmasks. This bit is a no-op in
-    // Vulkan, so isn't needed in that env. And the related capability is not
-    // allowed in WebGPU, so it is not allowed in that env.
-    StripAtomicCounterMemory,
     // Creates a strip-debug-info pass.
     // A strip-debug-info pass removes all debug instructions (as documented in
     // Section 3.32.2 of the SPIR-V spec) of the SPIR-V module to be optimized.
@@ -430,25 +424,10 @@ pub enum Passes {
     // Create a pass to do code sinking.  Code sinking is a transformation
     // where an instruction is moved into a more deeply nested construct.
     CodeSinking,
-    // Create a pass to adds initializers for OpVariable calls that require them
-    // in WebGPU. Currently this pass naively initializes variables that are
-    // missing an initializer with a null value. In the future it may initialize
-    // variables to the first value stored in them, if that is a constant.
-    GenerateWebGPUInitializers,
     // Create a pass to fix incorrect storage classes.  In order to make code
     // generation simpler, DXC may generate code where the storage classes do not
     // match up correctly.  This pass will fix the errors that it can.
     FixStorageClass,
-    // Create a pass to legalize OpVectorShuffle operands going into WebGPU. WebGPU
-    // forbids using 0xFFFFFFFF, which indicates an undefined result, so this pass
-    // converts those literals to 0.
-    LegalizeVectorShuffle,
-    // Create a pass to decompose initialized variables into a seperate variable
-    // declaration and an initial store.
-    DecomposeInitializedVariables,
-    // Create a pass to attempt to split up invalid unreachable merge-blocks and
-    // continue-targets to legalize for WebGPU.
-    SplitInvalidUnreachable,
     // Creates a graphics robust access pass.
     //
     // This pass injects code to clamp indexed accesses to buffers and internal

--- a/src/opt/tool.rs
+++ b/src/opt/tool.rs
@@ -128,7 +128,6 @@ fn pass_to_string(pass: super::Passes) -> Option<&'static str> {
 
     Some(match pass {
         Null => return None,
-        StripAtomicCounterMemory => "strip-atomic-counter-memory",
         StripDebugInfo => "strip-debug",
         StripReflectInfo => "strip-reflect",
         EliminateDeadFunctions => "eliminate-dead-functions",
@@ -177,11 +176,7 @@ fn pass_to_string(pass: super::Passes) -> Option<&'static str> {
         CombineAccessChains => "combine-access-chains",
         UpgradeMemoryModel => "upgrade-memory-model",
         CodeSinking => "code-sink",
-        GenerateWebGPUInitializers => "generate-webgpu-initializers",
         FixStorageClass => "fix-storage-class",
-        LegalizeVectorShuffle => "legalize-vector-shuffle",
-        DecomposeInitializedVariables => "decompose-initialized-variables",
-        SplitInvalidUnreachable => "split-invalid-unreachable",
         GraphicsRobustAccess => "graphics-robust-access",
         DescriptorScalarReplacement => "descriptor-scalar-replacement",
         WrapOpKill => "wrap-opkill",

--- a/tests/issue_22.rs
+++ b/tests/issue_22.rs
@@ -1,0 +1,57 @@
+use spirv_tools as spv;
+use spv::{assembler::Assembler, opt::Optimizer, val::Validator};
+
+const CONTENT: &str = r#"OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+       %file = OpString "file"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpLine %file 1 1
+               OpReturn
+               OpFunctionEnd"#;
+
+#[test]
+fn issue() {
+    let cas = spv::assembler::compiled::CompiledAssembler::default();
+    let assembled = cas
+        .assemble(CONTENT, spv::assembler::AssemblerOptions::default())
+        .expect("compiled failed to assemble");
+
+    let val = spv::val::create(None);
+    val.validate(&assembled, None)
+        .expect("failed to validate input assembly");
+
+    let mut iopt = spv::opt::tool::ToolOptimizer::default();
+    iopt.register_pass(spv::opt::Passes::StripDebugInfo);
+    let mut copt = spv::opt::compiled::CompiledOptimizer::default();
+    copt.register_pass(spv::opt::Passes::StripDebugInfo);
+
+    let iopt_output = iopt
+        .optimize(
+            &assembled,
+            &mut |msg| {
+                eprintln!("[tool] optimizer message: {:#?}", msg);
+            },
+            None,
+        )
+        .expect("failed to run tool optimizer");
+
+    let copt_output = copt
+        .optimize(
+            &assembled,
+            &mut |msg| {
+                eprintln!("[compiled] optimizer message: {:#?}", msg);
+            },
+            None,
+        )
+        .expect("failed to run compiled optimizer");
+
+    val.validate(iopt_output, None)
+        .expect("failed to validate tool output");
+    val.validate(copt_output, None)
+        .expect("failed to validate compiled output");
+}


### PR DESCRIPTION
Fixes #22. Make rust-side Passes enum match C++ side. The C++ side was updated in https://github.com/EmbarkStudios/spirv-tools-rs/pull/15 but the Rust side was missed.