### PR TITLE
Suppress deprecated sprintf warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,9 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = []
+ignore = [
+    "RUSTSEC-2021-0139", # ansi-term is Unmaintained - it is only a dev dependency
+]
 
 [licenses]
 unlicensed = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,7 @@ ignore = []
 
 [licenses]
 unlicensed = "deny"
-allow = ["MIT", "Apache-2.0"]
+allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"]
 copyleft = "deny"
 allow-osi-fsf-free = "neither"
 default = "deny"

--- a/spirv-tools-sys/build.rs
+++ b/spirv-tools-sys/build.rs
@@ -280,6 +280,7 @@ fn main() {
             .flag("-Wundef")
             .flag("-Wconversion")
             .flag("-Wno-sign-conversion")
+            .flag("-Wno-deprecated-declarations") // suppress warnings about sprintf
             .flag("-std=gnu++11");
     } else if compiler.is_like_clang() {
         build
@@ -298,6 +299,7 @@ fn main() {
             .flag("-Wundef")
             .flag("-Wconversion")
             .flag("-Wno-sign-conversion")
+            .flag("-Wno-deprecated-declarations") // suppress warnings about sprintf
             .flag("-ftemplate-depth=1024")
             .flag("-std=gnu++11");
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ impl std::error::Error for Error {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Diagnostic {
     pub line: usize,
     pub column: usize,


### PR DESCRIPTION
Compilation started failing after what I think was some Mac Xcode or system update (new compiler likely?).

This suppress this deprecation warning that failed the build:

```

warning: In file included from spirv-tools/source/opt/optimizer.cpp:28:
warning: In file included from spirv-tools/source/opt/passes.h:73:
warning: spirv-tools/source/opt/scalar_replacement_pass.h:42:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
warning:     sprintf(&name_[strlen(name_)], "%d", max_num_elements_);
warning:     ^
warning: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
warning: __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
warning: ^
warning: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
warning:         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
warning:
```

Also few misc fixes to make sure repo builds as been a while since we changed it.