### PR TITLE
Fix parsing of diagnostics from binaries

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -23,7 +23,7 @@ impl From<CmdError> for crate::error::Error {
         match ce {
             CmdError::BinaryNotFound(err) => Self {
                 inner: SpirvResult::Unsupported,
-                diagnostic: Some(format!("failed spawn executable: {err}").into()),
+                diagnostic: Some(format!("failed to spawn executable: {err}").into()),
             },
             CmdError::Io(err) => Self {
                 inner: SpirvResult::EndOfStream,

--- a/src/error.rs
+++ b/src/error.rs
@@ -136,7 +136,7 @@ impl Message {
                 // the source, but we don't want it, note we don't use trim since
                 // (other than the first \n) there can be significant whitespace
                 // at the beginning
-                full_message[ind + 1..].trim_end().to_owned(),
+                full_message[ind + 1..].trim_end_matches('\n').to_owned(),
             )
         } else {
             (full_message.into_owned(), String::new())

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,10 +14,18 @@ use std::fmt;
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.diagnostic {
-            Some(diag) => f.write_fmt(format_args!(
-                "error:{}:{} - {}",
-                diag.line, diag.column, diag.message
-            )),
+            Some(diag) => {
+                f.write_fmt(format_args!(
+                    "error:{}:{} - {}",
+                    diag.line, diag.column, diag.message
+                ))?;
+
+                if !diag.notes.is_empty() {
+                    f.write_fmt(format_args!("\n{}", diag.notes))?;
+                }
+
+                Ok(())
+            }
             None => f.write_str("an unknown error occurred"),
         }
     }
@@ -35,6 +43,7 @@ pub struct Diagnostic {
     pub column: usize,
     pub index: usize,
     pub message: String,
+    pub notes: String,
     pub is_text: bool,
 }
 
@@ -47,15 +56,14 @@ impl Diagnostic {
             return Err(shared::SpirvResult::Success);
         }
 
-        let message = std::ffi::CStr::from_ptr((*diag).error)
-            .to_string_lossy()
-            .to_string();
+        let (message, notes) = Message::message_and_notes_from_cstr((*diag).error);
 
         let res = Self {
             line: (*diag).position.line,
             column: (*diag).position.column,
             index: (*diag).position.index,
             message,
+            notes,
             is_text: (*diag).is_text_source,
         };
 
@@ -72,6 +80,7 @@ impl From<String> for Diagnostic {
             index: 0,
             is_text: false,
             message,
+            notes: String::new(),
         }
     }
 }
@@ -83,6 +92,7 @@ impl From<Message> for Diagnostic {
             column: msg.column,
             index: msg.index,
             message: msg.message,
+            notes: msg.notes,
             is_text: false,
         }
     }
@@ -96,6 +106,8 @@ pub struct Message {
     pub column: usize,
     pub index: usize,
     pub message: String,
+    /// Some messages can include additional information, typically instructions
+    pub notes: String,
 }
 
 impl Message {
@@ -108,6 +120,26 @@ impl Message {
             column: 0,
             index: 0,
             message,
+            notes: String::new(),
+        }
+    }
+
+    #[cfg(feature = "use-compiled-tools")]
+    unsafe fn message_and_notes_from_cstr(msg: *const std::os::raw::c_char) -> (String, String) {
+        let full_message = std::ffi::CStr::from_ptr(msg).to_string_lossy();
+
+        if let Some(ind) = full_message.find('\n') {
+            (
+                full_message[..ind].to_owned(),
+                // The compiled code always adds a trailing newline, even if it
+                // is the last note, presumably since it's copied directly from
+                // the source, but we don't want it, note we don't use trim since
+                // (other than the first \n) there can be significant whitespace
+                // at the beginning
+                full_message[ind + 1..].trim_end().to_owned(),
+            )
+        } else {
+            (full_message.into_owned(), String::new())
         }
     }
 
@@ -124,7 +156,8 @@ impl Message {
             } else {
                 Some(std::ffi::CStr::from_ptr(source).to_string_lossy())
             };
-            let message = std::ffi::CStr::from_ptr(msg).to_string_lossy();
+
+            let (message, notes) = Self::message_and_notes_from_cstr(msg);
 
             let (line, column, index) = if source_pos.is_null() {
                 (0, 0, 0)
@@ -148,7 +181,8 @@ impl Message {
                 line,
                 column,
                 index,
-                message: message.into_owned(),
+                message,
+                notes,
             }
         }
     }
@@ -184,6 +218,7 @@ impl Message {
                 source: None,
                 line: 0,
                 column: 0,
+                notes: String::new(),
             })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,12 +131,7 @@ impl Message {
         if let Some(ind) = full_message.find('\n') {
             (
                 full_message[..ind].to_owned(),
-                // The compiled code always adds a trailing newline, even if it
-                // is the last note, presumably since it's copied directly from
-                // the source, but we don't want it, note we don't use trim since
-                // (other than the first \n) there can be significant whitespace
-                // at the beginning
-                full_message[ind + 1..].trim_end_matches('\n').to_owned(),
+                full_message[ind + 1..].to_owned(),
             )
         } else {
             (full_message.into_owned(), String::new())

--- a/src/opt/compiled.rs
+++ b/src/opt/compiled.rs
@@ -119,6 +119,7 @@ impl Optimizer for CompiledOptimizer {
                                 column: 0,
                                 index: 0,
                                 message: "spirv optimizer indicated success but did not return a valid binary".to_owned(),
+                                notes: String::new(),
                                 is_text: false,
                             }),
                         });

--- a/tests/val.rs
+++ b/tests/val.rs
@@ -27,35 +27,21 @@ fn validate_tool(_input: &[u8]) -> Option<Result<(), spirv_tools::Error>> {
 #[test]
 fn gets_error_message() {
     let expected_msg = "error:0:0 - Loop header '6[%loop_header]' is targeted by 2 back-edge blocks but the standard requires exactly one";
-    let expected_notes = "  %loop_header = OpLabel";
+    let expected_notes = "  %loop_header = OpLabel\n";
 
-    match (validate_compiled(SPIRV_BIN), validate_tool(SPIRV_BIN)) {
-        (Some(resc), Some(rest)) => {
-            let cstr = resc.unwrap_err().to_string();
-            let tstr = rest.unwrap_err().to_string();
+    for res in validate_compiled(SPIRV_BIN)
+        .into_iter()
+        .chain(validate_tool(SPIRV_BIN).into_iter())
+    {
+        let err = res.unwrap_err();
+        let diag = err.diagnostic.as_ref().unwrap();
+        assert_eq!(diag.line, 0);
+        assert_eq!(diag.column, 0);
+        assert_eq!(diag.message, &expected_msg[12..]);
+        assert_eq!(diag.notes, expected_notes);
 
-            assert_eq!(cstr, tstr);
-
-            assert_eq!(&tstr[..113], expected_msg);
-            assert_eq!(&cstr[..113], expected_msg);
-
-            assert_eq!(&cstr[113 + 1..], expected_notes);
-            assert_eq!(&tstr[113 + 1..], expected_notes);
-        }
-        (Some(resc), None) => {
-            let diag = resc.unwrap_err().diagnostic.unwrap();
-            assert_eq!(diag.line, 0);
-            assert_eq!(diag.column, 0);
-            assert_eq!(diag.message, &expected_msg[12..]);
-            assert_eq!(diag.notes, expected_notes);
-        }
-        (None, Some(rest)) => {
-            let diag = rest.unwrap_err().diagnostic.unwrap();
-            assert_eq!(diag.line, 0);
-            assert_eq!(diag.column, 0);
-            assert_eq!(diag.message, &expected_msg[12..]);
-            assert_eq!(diag.notes, expected_notes);
-        }
-        _ => {}
+        let err_str = err.to_string();
+        assert_eq!(&err_str[..113], expected_msg);
+        assert_eq!(&err_str[113 + 1..], expected_notes);
     }
 }

--- a/tests/val.rs
+++ b/tests/val.rs
@@ -26,22 +26,35 @@ fn validate_tool(_input: &[u8]) -> Option<Result<(), spirv_tools::Error>> {
 
 #[test]
 fn gets_error_message() {
-    let cexpected_msg = "error:0:0 - Loop header '6[%loop_header]' is targeted by 2 back-edge blocks but the standard requires exactly one\n  %loop_header = OpLabel\n";
-    let texpected_msg = "error:0:0 - Loop header '6[%loop_header]' is targeted by 2 back-edge blocks but the standard requires exactly one";
+    let expected_msg = "error:0:0 - Loop header '6[%loop_header]' is targeted by 2 back-edge blocks but the standard requires exactly one";
+    let expected_notes = "  %loop_header = OpLabel";
+
     match (validate_compiled(SPIRV_BIN), validate_tool(SPIRV_BIN)) {
         (Some(resc), Some(rest)) => {
             let cstr = resc.unwrap_err().to_string();
             let tstr = rest.unwrap_err().to_string();
-            assert_eq!(&cstr[..111], &tstr[..111]);
 
-            assert_eq!(cstr, cexpected_msg);
-            assert_eq!(tstr, texpected_msg);
+            assert_eq!(cstr, tstr);
+
+            assert_eq!(&tstr[..113], expected_msg);
+            assert_eq!(&cstr[..113], expected_msg);
+
+            assert_eq!(&cstr[113 + 1..], expected_notes);
+            assert_eq!(&tstr[113 + 1..], expected_notes);
         }
         (Some(resc), None) => {
-            assert_eq!(resc.unwrap_err().to_string(), cexpected_msg);
+            let diag = resc.unwrap_err().diagnostic.unwrap();
+            assert_eq!(diag.line, 0);
+            assert_eq!(diag.column, 0);
+            assert_eq!(diag.message, &expected_msg[12..]);
+            assert_eq!(diag.notes, expected_notes);
         }
         (None, Some(rest)) => {
-            assert_eq!(rest.unwrap_err().to_string(), texpected_msg);
+            let diag = rest.unwrap_err().diagnostic.unwrap();
+            assert_eq!(diag.line, 0);
+            assert_eq!(diag.column, 0);
+            assert_eq!(diag.message, &expected_msg[12..]);
+            assert_eq!(diag.notes, expected_notes);
         }
         _ => {}
     }


### PR DESCRIPTION
When spirv tools output error messages, particularly validation, they often print out a block of extra information (typically instructions) after the top level error message. The compiled versions were "handling" this since it was all stuffed into a single string, but when parsing the messages from stderr we were just discarding this additional information since they weren't formatted how the top-level message was formatted. So now we actually handle that, and have an additional `notes` field in the message/diagnostic that we parse that additional information into so that it can be treated distinctly from the top-level error message.