### PR TITLE
Add Vulkan 1.3 & SPIR-V 1.6 envs and set correct default

### DIFF
--- a/spirv-tools-sys/src/shared.rs
+++ b/spirv-tools-sys/src/shared.rs
@@ -68,12 +68,16 @@ pub enum TargetEnv {
     Universal_1_5,
     /// Vulkan 1.2 latest revision.
     Vulkan_1_2,
+    /// Vulkan 1.3 latest revision.
+    Vulkan_1_3,
+    /// SPIR-V 1.6 latest revision, no other restrictions.
+    Universal_1_6,
 }
 
 impl Default for TargetEnv {
     fn default() -> Self {
         // This is the default target environment for (AFAICT) all spirv-tools
-        Self::Universal_1_5
+        Self::Universal_1_6
     }
 }
 
@@ -86,12 +90,14 @@ impl std::str::FromStr for TargetEnv {
             "vulkan1.0" => Self::Vulkan_1_0,
             "vulkan1.1" => Self::Vulkan_1_1,
             "vulkan1.2" => Self::Vulkan_1_2,
+            "vulkan1.3" => Self::Vulkan_1_3,
             "spv1.0" => Self::Universal_1_0,
             "spv1.1" => Self::Universal_1_1,
             "spv1.2" => Self::Universal_1_2,
             "spv1.3" => Self::Universal_1_3,
             "spv1.4" => Self::Universal_1_4,
             "spv1.5" => Self::Universal_1_5,
+            "spv1.6" => Self::Universal_1_6,
             "opencl1.2embedded" => Self::OpenCLEmbedded_1_2,
             "opencl1.2" => Self::OpenCL_1_2,
             "opencl2.0embedded" => Self::OpenCLEmbedded_2_0,
@@ -118,12 +124,14 @@ impl fmt::Display for TargetEnv {
             Self::Vulkan_1_0 => "vulkan1.0",
             Self::Vulkan_1_1 => "vulkan1.1",
             Self::Vulkan_1_2 => "vulkan1.2",
+            Self::Vulkan_1_3 => "vulkan1.3",
             Self::Universal_1_0 => "spv1.0",
             Self::Universal_1_1 => "spv1.1",
             Self::Universal_1_2 => "spv1.2",
             Self::Universal_1_3 => "spv1.3",
             Self::Universal_1_4 => "spv1.4",
             Self::Universal_1_5 => "spv1.5",
+            Self::Universal_1_6 => "spv1.6",
             Self::OpenCLEmbedded_1_2 => "opencl1.2embedded",
             Self::OpenCL_1_2 => "opencl1.2",
             Self::OpenCLEmbedded_2_0 => "opencl2.0embedded",


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
Trivial change adding missing env enum variants & conversion to SPIR-V tool env strings.
Default in SPIR-V tools is also `static constexpr auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_6;` everywhere now, so update that too.